### PR TITLE
Add support for remote vector tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,35 @@ var opts_raster = {
 server.layer('mylayer')
     .route('t.pbf').use(vtile(opts_vector))
     .route('t.png').use(vtileraster(opts_raster, {
-        tilesource: ['mylayer', 't.pbf']
+        tilesource: {layer: 'mylayer', file: 't.pbf'}
     }))
     .route('i.json').use(vtileraster(opts_raster, {
-        tilesource: ['mylayer', 't.pbf'],
+        tilesource: {layer: 'mylayer', file: 't.pbf'},
         interactivity: true
     }));
 ```
+
+### Remote tile server
+
+When the vector tiles are served by another server, you can
+use a tms URL to fetch them, for example:
+
+```js
+var options = {
+    xml: '/path/to/mapnik-style.xml',
+    tileSize: 256,
+    metatile: 1,
+    bufferSize: 128,
+    tilesource: {
+        tms: 'http://domain.com/tiles/{z}/{x}/{y}.pbf'
+    }
+
+};
+
+server.layer('mylayer')
+      .route('t.png').use(vtileraster(options));
+```
+
 
 ### Mapnik XML Notes
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "async": "~1.2.0",
     "async-cache": "1.0.0",
     "lodash": "~2.4.1",
+    "request": "^2.60.0",
     "tilestrata-dependency": "~0.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi :)

This is a suggestion to add support for remote vector tiles, pushed for discussion.
This is our current use case, and I guess it will be for others, as soon as you want to separate the vector tiles provider server and the servers that style those tiles to produce raster images.

This implementation also changes the options API: instead of having hard coded a two indices array, we pass an object as `tilesource`, which defines the behaviour: use `tilestrata-vtile` dependecy (and then pass `layer` and `file` keys), or use a remote URL with TMS format. This change is to allow more format to be supported in the future (like a tilejson URL, or maybe a local directory with tiles).

I'm just playing around with tilestrata (nice move :) ) since today, so I may be totally missing a concept.
I've first thought about making my own plugin instead of trying to patch this one, but I quickly changed my mind because of the amount of code duplication.

Thanks for your review!
